### PR TITLE
Response streams

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ tests_require = [
 
 setup(
     name="tempoiq",
-    version="1.0.1",
+    version="1.0.2",
     author="TempoIQ Inc",
     author_email="aaron.brenzel@tempoiq.com",
     url="http://github.com/tempoiq/tempoiq-python/",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ tests_require = [
 
 setup(
     name="tempoiq",
-    version="1.0.2",
+    version="1.0.1",
     author="TempoIQ Inc",
     author_email="aaron.brenzel@tempoiq.com",
     url="http://github.com/tempoiq/tempoiq-python/",

--- a/tempoiq/client.py
+++ b/tempoiq/client.py
@@ -4,6 +4,7 @@ import urllib
 from protocol.encoder import WriteEncoder, CreateEncoder, ReadEncoder
 from protocol.query.builder import QueryBuilder
 from response import Response, SensorPointsResponse, DeleteDatapointsResponse
+from response import StreamResponse
 from response import RuleResponse, DeviceResponse, ResponseException
 from endpoint import media_type, media_types
 
@@ -88,6 +89,7 @@ class Client(object):
         global DATAPOINT_ACCEPT_TYPE
         DATAPOINT_ACCEPT_TYPE = media_type('datapoint-collection',
                                            read_version)
+        self.read_version = read_version
 
     def create_device(self, device):
         """Create a new device
@@ -161,7 +163,10 @@ class Client(object):
         headers = media_types(accept_headers, content_header)
         resp = self.endpoint.get(url, j, headers=headers)
         fetcher = make_fetcher(self.endpoint, url, headers)
-        return SensorPointsResponse(resp, self.endpoint, fetcher)
+        if self.read_version == 'v2':
+            return SensorPointsResponse(resp, self.endpoint, fetcher)
+        else:
+            return StreamResponse(resp, self.endpoint, fetcher)
 
     def search_devices(self, query):
         #TODO - actually use the size param

--- a/tempoiq/client.py
+++ b/tempoiq/client.py
@@ -82,9 +82,12 @@ class Client(object):
     create_encoder = CreateEncoder()
     read_encoder = ReadEncoder()
 
-    def __init__(self, endpoint):
+    def __init__(self, endpoint, read_version='v2'):
         self.endpoint = endpoint
         self.monitoring_client = MonitoringClient(self.endpoint)
+        global DATAPOINT_ACCEPT_TYPE
+        DATAPOINT_ACCEPT_TYPE = media_type('datapoint-collection',
+                                           read_version)
 
     def create_device(self, device):
         """Create a new device

--- a/tempoiq/client.py
+++ b/tempoiq/client.py
@@ -10,7 +10,7 @@ from endpoint import media_type, media_types
 
 ERROR_ACCEPT_TYPE = media_type('error', 'v1')
 DEVICE_ACCEPT_TYPE = media_type('device-collection', 'v2')
-DATAPOINT_ACCEPT_TYPE = media_type('datapoint-collection', 'v2')
+DATAPOINT_ACCEPT_TYPE = media_type('datapoint-collection', 'v3')
 QUERY_CONTENT_TYPE = media_type('query', 'v1')
 
 

--- a/tempoiq/client.py
+++ b/tempoiq/client.py
@@ -9,12 +9,6 @@ from response import RuleResponse, DeviceResponse, ResponseException
 from endpoint import media_type, media_types
 
 
-ERROR_ACCEPT_TYPE = media_type('error', 'v1')
-DEVICE_ACCEPT_TYPE = media_type('device-collection', 'v2')
-DATAPOINT_ACCEPT_TYPE = media_type('datapoint-collection', 'v3')
-QUERY_CONTENT_TYPE = media_type('query', 'v1')
-
-
 def escape(s):
     return urllib.quote(s, safe='')
 
@@ -86,9 +80,11 @@ class Client(object):
     def __init__(self, endpoint, read_version='v2'):
         self.endpoint = endpoint
         self.monitoring_client = MonitoringClient(self.endpoint)
-        global DATAPOINT_ACCEPT_TYPE
-        DATAPOINT_ACCEPT_TYPE = media_type('datapoint-collection',
+        self.DATAPOINT_ACCEPT_TYPE = media_type('datapoint-collection',
                                            read_version)
+        self.ERROR_ACCEPT_TYPE = media_type('error', 'v1')
+        self.DEVICE_ACCEPT_TYPE = media_type('device-collection', 'v2')
+        self.QUERY_CONTENT_TYPE = media_type('query', 'v1')
         self.read_version = read_version
 
     def create_device(self, device):
@@ -158,8 +154,8 @@ class Client(object):
     def read(self, query):
         url = urlparse.urljoin(self.endpoint.base_url, 'read/')
         j = json.dumps(query, default=self.read_encoder.default)
-        accept_headers = [ERROR_ACCEPT_TYPE, DATAPOINT_ACCEPT_TYPE]
-        content_header = QUERY_CONTENT_TYPE
+        accept_headers = [self.ERROR_ACCEPT_TYPE, self.DATAPOINT_ACCEPT_TYPE]
+        content_header = self.QUERY_CONTENT_TYPE
         headers = media_types(accept_headers, content_header)
         resp = self.endpoint.get(url, j, headers=headers)
         fetcher = make_fetcher(self.endpoint, url, headers)
@@ -172,8 +168,8 @@ class Client(object):
         #TODO - actually use the size param
         url = urlparse.urljoin(self.endpoint.base_url, 'devices/')
         j = json.dumps(query, default=self.read_encoder.default)
-        accept_headers = [ERROR_ACCEPT_TYPE, DEVICE_ACCEPT_TYPE]
-        content_header = QUERY_CONTENT_TYPE
+        accept_headers = [self.ERROR_ACCEPT_TYPE, self.DEVICE_ACCEPT_TYPE]
+        content_header = self.QUERY_CONTENT_TYPE
         headers = media_types(accept_headers, content_header)
         fetcher = make_fetcher(self.endpoint, url, headers)
         return DeviceResponse(self.endpoint.get(url, j, headers=headers),

--- a/tempoiq/endpoint.py
+++ b/tempoiq/endpoint.py
@@ -64,7 +64,7 @@ class HTTPEndpoint(object):
             self.base_url = base_url + '/v2/'
 
         self.headers = {
-            'User-Agent': 'tempoiq-python/%s' % "1.0.1",
+            'User-Agent': 'tempoiq-python/%s' % "1.0.2",
             'Accept-Encoding': 'gzip'
         }
         self.auth = HTTPBasicAuth(key, secret)

--- a/tempoiq/protocol/cursor.py
+++ b/tempoiq/protocol/cursor.py
@@ -216,6 +216,12 @@ class StreamResponseCursor(Cursor):
         self.stream_info = StreamInfo(data['streams'])
         self.manager = StreamManager(self, data, self.page_size)
 
+    def __iter__(self):
+        streams = self.streams
+        iterators = [(s, iter(s)) for s in streams]
+        for stream, it in iterators:
+            yield ((stream.device, stream.sensor), it.next())
+
     def _fetch_next(self):
         try:
             cursor_obj = self._raw_data['next_page']['next_query']

--- a/tempoiq/protocol/cursor.py
+++ b/tempoiq/protocol/cursor.py
@@ -231,3 +231,8 @@ class StreamResponseCursor(Cursor):
     def bind_stream(self, **kwargs):
         stream_info = self.stream_info.get_one(**kwargs)
         return PointStream(stream_info, self.manager)
+
+    @property
+    def streams(self):
+        return [PointStream(si, self.manager) for
+                si in self.stream_info.headers]

--- a/tempoiq/protocol/cursor.py
+++ b/tempoiq/protocol/cursor.py
@@ -112,6 +112,9 @@ class DataPointsCursor(Cursor):
             self.data = make_row_generator(new_data['data'])
         except KeyError:
             raise StopIteration
-        except Exception, e:
-            print e
-            raise StopIteration
+        except Exception:
+            raise
+
+
+class StreamResponseCursor(Cursor):
+    pass

--- a/tempoiq/protocol/cursor.py
+++ b/tempoiq/protocol/cursor.py
@@ -215,7 +215,6 @@ class StreamResponseCursor(Cursor):
         self.page_size = len(data['data'])
         self.stream_info = StreamInfo(data['streams'])
         self.manager = StreamManager(self, data, self.page_size)
-        #self.data = make_row_generator(data['data'])
 
     def _fetch_next(self):
         try:

--- a/tempoiq/protocol/encoder.py
+++ b/tempoiq/protocol/encoder.py
@@ -146,11 +146,18 @@ class ReadEncoder(TempoIQEncoder):
         else:
             name = 'or'
 
+        object_type = None
         result = []
         for selector in clause.selectors:
             if isinstance(selector, (AndClause, OrClause)):
                 result.append(self.encode_compound_clause(selector))
             elif isinstance(selector, ScalarSelector):
+                if object_type is None:
+                    object_type = selector.selection_type
+                else:
+                    if object_type != selector.selection_type:
+                        msg = 'Selectors in a compound clause must be of uniform type'
+                        raise TypeError(msg)
                 result.append(self.encode_scalar_selector(selector))
             else:
                 raise ValueError("invalid selector type")

--- a/tempoiq/protocol/query/builder.py
+++ b/tempoiq/protocol/query/builder.py
@@ -200,7 +200,10 @@ class QueryBuilder(object):
         if self.object_type == 'sensors':
             start = kwargs['start']
             end = kwargs['end']
+            limit = kwargs.get('limit')
             args = {'start': start, 'stop': end}
+            if limit is not None:
+                args['limit'] = limit
             #this is set here to be used by the encoder to correctly specify
             #the last step of the operation in the JSON
             self.operation = APIOperation('read', args)

--- a/tempoiq/protocol/query/selection.py
+++ b/tempoiq/protocol/query/selection.py
@@ -90,10 +90,6 @@ def and_(selectors):
     for selector in selectors:
         if object_type is None:
             object_type = selector.selection_type
-        else:
-            if object_type != selector.selection_type:
-                msg = 'Selectors in an "and" clause must be of uniform type'
-                raise TypeError(msg)
         s.add(selector)
     s.selection_type = object_type
     return s
@@ -109,10 +105,6 @@ def or_(selectors):
     for selector in selectors:
         if object_type is None:
             object_type = selector.selection_type
-        else:
-            if object_type != selector.selection_type:
-                msg = 'Selectors in an "or" clause must be of uniform type'
-                raise TypeError(msg)
         s.add(selector)
     s.selection_type = object_type
     return s

--- a/tempoiq/protocol/row.py
+++ b/tempoiq/protocol/row.py
@@ -39,6 +39,22 @@ class Row(object):
                 yield ((device, sensor), self.values[device][sensor])
 
 
+class PointStream(object):
+    def __init__(self, stream_info, manager):
+        self.stream_info = stream_info
+        self.manager = manager
+        self._id = stream_info['id']
+        self.key = self._id
+
+    def __iter__(self):
+        while True:
+            data = self.manager.next(self)
+            value = data.get(self._id)
+            if value is None:
+                continue
+            yield value
+
+
 class StreamInfo(object):
     def __init__(self, headers):
         self.headers = headers

--- a/tempoiq/protocol/row.py
+++ b/tempoiq/protocol/row.py
@@ -3,6 +3,7 @@ from tempoiq.temporal.validate import convert_iso_stamp
 from device import Device
 from sensor import Sensor
 from stream import Stream
+from point import Point
 from query.selection import AndClause, Compound, OrClause, ScalarSelector, and_
 from query.selection import Selection
 
@@ -53,10 +54,12 @@ class PointStream(object):
     def __iter__(self):
         while True:
             data = self.manager.next(self)
-            value = data.get(self._id)
+            time_str = data['t']
+            value = data['data'].get(self._id)
             if value is None:
                 continue
-            yield value
+            timestamp = convert_iso_stamp(time_str)
+            yield Point(timestamp, value)
 
     @property
     def device(self):

--- a/tempoiq/protocol/row.py
+++ b/tempoiq/protocol/row.py
@@ -1,9 +1,10 @@
 from tempoiq.temporal.validate import convert_iso_stamp
+from query.selection import AndClause, Compound, OrClause, ScalarSelector
 
 
 class Row(object):
-    """Data from one or more sensors at a single timestamp. Returned when reading
-    sensor data.
+    """Data from one or more sensors at a single timestamp. Returned when
+    reading sensor data.
 
     Example values dict of a row with a single sensor, *temperature*\ , on a
     single device, *test1*\ ::
@@ -24,3 +25,79 @@ class Row(object):
         for device in self.values:
             for sensor in self.values[device]:
                 yield ((device, sensor), self.values[device][sensor])
+
+
+class StreamInfo(object):
+    def __init__(self, headers):
+        self.headers = headers
+
+    def filter(self, selection):
+        evaluator = SelectionEvaluator(selection)
+        return evaluator.filter(self.headers)
+
+
+class SelectionEvaluator(object):
+    def __init__(self, selection):
+        self.selection = selection
+
+    def filter(self, headers):
+        for header in headers:
+            result = self._evaluate_selector(self.selection.selection, header)
+            if result:
+                yield header
+
+    def _evaluate_compound_clause(self, clause, header):
+        if isinstance(clause, AndClause):
+            return self._evaluate_and_clause(clause, header)
+        elif isinstance(clause, OrClause):
+            return self._evaluate_or_clause(clause, header)
+        else:
+            raise ValueError('Invalid compound clause in selection')
+
+    def _evaluate_and_clause(self, clause, header):
+        for selector in clause.selectors:
+            matches = self._evaluate_selector(selector, header)
+            if not matches:
+                return False
+        return True
+
+    def _evaluate_or_clause(self, clause, header):
+        all_matches = []
+        for selector in clause.selectors:
+            matches = self._evaluate_selector(selector, header)
+            all_matches.append(matches)
+        if any(all_matches):
+            return True
+        return False
+
+    def _evaluate_selector_on_object(self, selector, header, object_type):
+        if selector.key == 'key':
+            return selector.value == header[object_type]['key']
+        elif selector.key == 'name':
+            return selector.value == header[object_type]['name']
+        else:
+            key = selector.value.keys()[0]
+            header_value = header[object_type]['attributes'].get(key)
+            return selector.value[key] == header_value
+
+    def _evaluate_device_selector(self, selector, header):
+        return self._evaluate_selector_on_object(selector, header, 'device')
+
+    def _evaluate_sensor_selector(self, selector, header):
+        return self._evaluate_selector_on_object(selector, header, 'sensor')
+
+    def _evaluate_scalar_selector(self, selector, header):
+        if selector.selection_type == 'devices':
+            return self._evaluate_device_selector(selector, header)
+        elif selector.selection_type == 'sensors':
+            return self._evaluate_sensor_selector(selector, header)
+        else:
+            raise ValueError('Invalid selection type in selection')
+
+    def _evaluate_selector(self, selector, header):
+        if isinstance(selector, Compound):
+            return self._evaluate_compound_clause(selector, header)
+        elif isinstance(selector, ScalarSelector):
+            return self._evaluate_scalar_selector(selector, header)
+        else:
+            raise ValueError('Invalid selector in selection')

--- a/tempoiq/protocol/row.py
+++ b/tempoiq/protocol/row.py
@@ -45,7 +45,7 @@ class PointStream(object):
     def __init__(self, stream_info, manager):
         self.stream_info = stream_info
         self.manager = manager
-        self._id = stream_info['id']
+        self._id = str(stream_info['id'])
         self.key = str(uuid.uuid1())
         self._device = None
         self._sensor = None

--- a/tempoiq/protocol/row.py
+++ b/tempoiq/protocol/row.py
@@ -125,6 +125,8 @@ class SelectionEvaluator(object):
             return selector.value == header[object_type]['key']
         elif selector.key == 'name':
             return selector.value == header[object_type]['name']
+        elif selector.key == 'function':
+            return selector.value == header.get('function')
         else:
             key = selector.value.keys()[0]
             header_value = header[object_type]['attributes'].get(key)
@@ -136,11 +138,16 @@ class SelectionEvaluator(object):
     def _evaluate_sensor_selector(self, selector, header):
         return self._evaluate_selector_on_object(selector, header, 'sensor')
 
+    def _evaluate_stream_selector(self, selector, header):
+        return self._evaluate_selector_on_object(selector, header, 'stream')
+
     def _evaluate_scalar_selector(self, selector, header):
         if selector.selection_type == 'devices':
             return self._evaluate_device_selector(selector, header)
         elif selector.selection_type == 'sensors':
             return self._evaluate_sensor_selector(selector, header)
+        elif selector.selection_type == 'streams':
+            return self._evaluate_stream_selector(selector, header)
         else:
             raise ValueError('Invalid selection type in selection')
 

--- a/tempoiq/protocol/row.py
+++ b/tempoiq/protocol/row.py
@@ -1,3 +1,4 @@
+import uuid
 from tempoiq.temporal.validate import convert_iso_stamp
 from device import Device
 from sensor import Sensor
@@ -44,7 +45,10 @@ class PointStream(object):
         self.stream_info = stream_info
         self.manager = manager
         self._id = stream_info['id']
-        self.key = self._id
+        self.key = str(uuid.uuid1())
+        self._device = None
+        self._sensor = None
+        self.function = stream_info.get('function')
 
     def __iter__(self):
         while True:
@@ -53,6 +57,22 @@ class PointStream(object):
             if value is None:
                 continue
             yield value
+
+    @property
+    def device(self):
+        if self._device is None:
+            si = self.stream_info['device']
+            self._device = Device(si['key'], si.get('name', ''),
+                                  si['attributes'])
+        return self._device
+
+    @property
+    def sensor(self):
+        if self._sensor is None:
+            si = self.stream_info['sensor']
+            self._sensor = Sensor(si['key'], si.get('name', ''),
+                                  si['attributes'])
+        return self._sensor
 
 
 class StreamInfo(object):

--- a/tempoiq/protocol/row.py
+++ b/tempoiq/protocol/row.py
@@ -35,6 +35,16 @@ class StreamInfo(object):
         evaluator = SelectionEvaluator(selection)
         return evaluator.filter(self.headers)
 
+    def get_one(self, selection):
+        evaluator = SelectionEvaluator(selection)
+        results = [r for r in evaluator.filter(self.headers)]
+        if len(results) < 1:
+            raise ValueError('Selection would return no results')
+        elif len(results) > 1:
+            raise ValueError('Selection would return more than one result')
+        else:
+            return results[0]
+
 
 class SelectionEvaluator(object):
     def __init__(self, selection):

--- a/tempoiq/protocol/stream.py
+++ b/tempoiq/protocol/stream.py
@@ -1,6 +1,8 @@
 from query.selection import ScalarSelectable
 
 
+#used for enabling the search DSL for substream selection, not up for release
+#yet
 class Stream(object):
     function = ScalarSelectable('streams', 'function')
 

--- a/tempoiq/protocol/stream.py
+++ b/tempoiq/protocol/stream.py
@@ -1,0 +1,10 @@
+from query.selection import ScalarSelectable
+
+
+class Stream(object):
+    function = ScalarSelectable('streams', 'function')
+
+    def __init__(self, device, sensor, function):
+        self.device = device
+        self.sensor = sensor
+        self.function = function

--- a/tempoiq/response.py
+++ b/tempoiq/response.py
@@ -1,5 +1,6 @@
 import json
 from protocol.cursor import DeviceCursor, StreamResponseCursor
+from protocol.cursor import DataPointsCursor
 from protocol.decoder import TempoIQDecoder
 
 
@@ -82,6 +83,17 @@ class DeviceResponse(Response):
 class SensorPointsResponse(Response):
     def __init__(self, resp, session, fetcher):
         super(SensorPointsResponse, self).__init__(resp, session)
+        self.fetcher = fetcher
+        if self.successful == SUCCESS:
+            self.parse(self.body)
+
+    def parse(self, body):
+        self.data = DataPointsCursor(self, json.loads(body), self.fetcher)
+
+
+class StreamResponse(Response):
+    def __init__(self, resp, session, fetcher):
+        super(StreamResponse, self).__init__(resp, session)
         self.fetcher = fetcher
         if self.successful == SUCCESS:
             self.parse(self.body)

--- a/tempoiq/response.py
+++ b/tempoiq/response.py
@@ -14,7 +14,7 @@ class ResponseException(Exception):
 
     def __init__(self, response):
         self.response = response
-        self.msg = 'TempoDB response returned status: %d' % response.status
+        self.msg = 'TempoIQ response returned status: %d' % response.status
 
     def __repr__(self):
         return self.msg
@@ -24,7 +24,7 @@ class ResponseException(Exception):
 
 
 class Response(object):
-    """Represents responses from the TempoDB API.  The Response object has
+    """Represents responses from the TempoIQ API.  The Response object has
     several useful attributes after it is created:
 
         * successful: whether the overall request was successful (see below)

--- a/tempoiq/response.py
+++ b/tempoiq/response.py
@@ -1,5 +1,5 @@
 import json
-from protocol.cursor import DeviceCursor, DataPointsCursor
+from protocol.cursor import DeviceCursor, StreamResponseCursor
 from protocol.decoder import TempoIQDecoder
 
 
@@ -87,7 +87,7 @@ class SensorPointsResponse(Response):
             self.parse(self.body)
 
     def parse(self, body):
-        self.data = DataPointsCursor(self, json.loads(body), self.fetcher)
+        self.data = StreamResponseCursor(self, json.loads(body), self.fetcher)
 
 
 class RuleResponse(Response):

--- a/tempoiq/session.py
+++ b/tempoiq/session.py
@@ -2,7 +2,7 @@ from client import Client
 from endpoint import HTTPEndpoint
 
 
-def get_session(url, key, secret):
+def get_session(url, key, secret, read_version='v2'):
     """Get a :class:`tempoiq.client.Client` instance with the given session
     information.
 
@@ -12,4 +12,4 @@ def get_session(url, key, secret):
     :param String secret: API secret
     :rtype: :class:`tempoiq.client.Client`"""
     endpoint = HTTPEndpoint(url, key, secret)
-    return Client(endpoint)
+    return Client(endpoint, read_version=read_version)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -45,7 +45,8 @@ class TestClient(unittest.TestCase):
         content_header = QUERY_CONTENT_TYPE
         headers = media_types(accept_headers, content_header)
         merged = merge_headers(self.client.endpoint.headers, headers)
-        self.client.read(query)
+        resp = self.client.read(query)
+        self.assertIsInstance(resp, SensorPointsResponse)
         self.client.endpoint.pool.get.assert_called_once_with(
             url, data=j, auth=self.client.endpoint.auth,
             headers=merged)
@@ -62,7 +63,8 @@ class TestClient(unittest.TestCase):
         content_header = QUERY_CONTENT_TYPE
         headers = media_types(accept_headers, content_header)
         merged = merge_headers(self.client.endpoint.headers, headers)
-        self.client.read(query)
+        resp = self.client.read(query)
+        self.assertIsInstance(resp, StreamResponse)
         self.client.endpoint.pool.get.assert_called_once_with(
             url, data=j, auth=self.client.endpoint.auth,
             headers=merged)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -41,8 +41,9 @@ class TestClient(unittest.TestCase):
         j = json.dumps(query, default=self.client.create_encoder.default)
         url = 'http://test.tempo-iq.com/v2/read/'
         DATAPOINT_ACCEPT_TYPE = media_type('datapoint-collection', 'v2')
-        accept_headers = [ERROR_ACCEPT_TYPE, DATAPOINT_ACCEPT_TYPE]
-        content_header = QUERY_CONTENT_TYPE
+        accept_headers = [self.client.ERROR_ACCEPT_TYPE,
+                          self.client.DATAPOINT_ACCEPT_TYPE]
+        content_header = self.client.QUERY_CONTENT_TYPE
         headers = media_types(accept_headers, content_header)
         merged = merge_headers(self.client.endpoint.headers, headers)
         resp = self.client.read(query)
@@ -59,8 +60,9 @@ class TestClient(unittest.TestCase):
                                   read_version='v3')
         monkeypatch_requests(self.client.endpoint)
         DATAPOINT_ACCEPT_TYPE = media_type('datapoint-collection', 'v3')
-        accept_headers = [ERROR_ACCEPT_TYPE, DATAPOINT_ACCEPT_TYPE]
-        content_header = QUERY_CONTENT_TYPE
+        accept_headers = [self.client.ERROR_ACCEPT_TYPE,
+                          self.client.DATAPOINT_ACCEPT_TYPE]
+        content_header = self.client.QUERY_CONTENT_TYPE
         headers = media_types(accept_headers, content_header)
         merged = merge_headers(self.client.endpoint.headers, headers)
         resp = self.client.read(query)
@@ -73,8 +75,9 @@ class TestClient(unittest.TestCase):
         query = {}
         j = json.dumps(query, default=self.client.create_encoder.default)
         url = 'http://test.tempo-iq.com/v2/devices/'
-        accept_headers = [ERROR_ACCEPT_TYPE, DEVICE_ACCEPT_TYPE]
-        content_header = QUERY_CONTENT_TYPE
+        accept_headers = [self.client.ERROR_ACCEPT_TYPE,
+                          self.client.DEVICE_ACCEPT_TYPE]
+        content_header = self.client.QUERY_CONTENT_TYPE
         headers = media_types(accept_headers, content_header)
         merged = merge_headers(self.client.endpoint.headers, headers)
         self.client.search_devices(query)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,7 +4,7 @@ import datetime
 from tempoiq.session import get_session
 from tempoiq.protocol.device import Device
 from tempoiq.client import *
-from tempoiq.endpoint import merge_headers
+from tempoiq.endpoint import merge_headers, media_type
 from monkey import monkeypatch_requests
 
 
@@ -40,6 +40,24 @@ class TestClient(unittest.TestCase):
         query = {}
         j = json.dumps(query, default=self.client.create_encoder.default)
         url = 'http://test.tempo-iq.com/v2/read/'
+        DATAPOINT_ACCEPT_TYPE = media_type('datapoint-collection', 'v2')
+        accept_headers = [ERROR_ACCEPT_TYPE, DATAPOINT_ACCEPT_TYPE]
+        content_header = QUERY_CONTENT_TYPE
+        headers = media_types(accept_headers, content_header)
+        merged = merge_headers(self.client.endpoint.headers, headers)
+        self.client.read(query)
+        self.client.endpoint.pool.get.assert_called_once_with(
+            url, data=j, auth=self.client.endpoint.auth,
+            headers=merged)
+
+    def test_client_sends_non_default_media_type_in_read_query(self):
+        query = {}
+        j = json.dumps(query, default=self.client.create_encoder.default)
+        url = 'http://test.tempo-iq.com/v2/read/'
+        self.client = get_session('http://test.tempo-iq.com/', 'foo', 'bar',
+                                  read_version='v3')
+        monkeypatch_requests(self.client.endpoint)
+        DATAPOINT_ACCEPT_TYPE = media_type('datapoint-collection', 'v3')
         accept_headers = [ERROR_ACCEPT_TYPE, DATAPOINT_ACCEPT_TYPE]
         content_header = QUERY_CONTENT_TYPE
         headers = media_types(accept_headers, content_header)

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -151,6 +151,13 @@ class TestReadEncoder(unittest.TestCase):
         }
         self.assertEquals(j, json.dumps(expected))
 
+    def test_encode_invalid_selection(self):
+        clause = or_([Device.key == 'foo', Sensor.key == 'bar'])
+        selection = Selection()
+        selection.add(clause)
+        with self.assertRaises(TypeError):
+            json.dumps(selection, default=self.read_encoder.default)
+
     def test_encode_empty_selection(self):
         selection = Selection()
         j = json.dumps(selection, default=self.read_encoder.default)

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -55,7 +55,7 @@ class TestEndpoint(unittest.TestCase):
     def test_endpoint_constructor(self):
         self.assertEquals(self.end.base_url, 'http://www.nothing.com/v2/')
         self.assertEquals(self.end.headers['User-Agent'],
-                          'tempoiq-python/%s' % '1.0.1')
+                          'tempoiq-python/%s' % '1.0.2')
         self.assertEquals(self.end.headers['Accept-Encoding'], 'gzip')
         self.assertTrue(hasattr(self.end, 'auth'))
 
@@ -63,7 +63,7 @@ class TestEndpoint(unittest.TestCase):
         self.end = p.HTTPEndpoint('http://www.nothing.com', 'foo', 'bar')
         self.assertEquals(self.end.base_url, 'http://www.nothing.com/v2/')
         self.assertEquals(self.end.headers['User-Agent'],
-                          'tempoiq-python/%s' % '1.0.1')
+                          'tempoiq-python/%s' % '1.0.2')
         self.assertEquals(self.end.headers['Accept-Encoding'], 'gzip')
         self.assertTrue(hasattr(self.end, 'auth'))
 

--- a/tests/test_protocol_cursor.py
+++ b/tests/test_protocol_cursor.py
@@ -334,14 +334,27 @@ class TestProtocolStreamResponseCursor(unittest.TestCase):
         def fetcher(cursor):
             raise StopIteration
 
-        data = {'data': [{1: 1}, {1: 2}, {1: 3}],
+        data = {'data': [
+                    {
+                        't': '2015-01-01T00:00:00',
+                        'data': {1: 1},
+                    },
+                    {
+                        't': '2015-01-02T00:00:00',
+                        'data': {1: 2},
+                    },
+                    {
+                        't': '2015-01-03T00:00:00',
+                        'data': {1: 3},
+                    }
+                ],
                 'streams': [{'device': {'key': 'foo'}, 'id': 1}],
                 'next_page': {'next_query': None}}
 
         cursor = StreamResponseCursor(None, data, fetcher)
         stream = cursor.bind_stream(device_key='foo')
         data = [s for s in stream]
-        self.assertEquals(data, [1, 2, 3])
+        self.assertEquals([d.value for d in data], [1, 2, 3])
 
     def test_bind_one_stream_with_missing_data(self):
         StreamManager.MAX_PAGES = 2
@@ -349,14 +362,27 @@ class TestProtocolStreamResponseCursor(unittest.TestCase):
         def fetcher(cursor):
             raise StopIteration
 
-        data = {'data': [{1: 1}, {2: 2}, {1: 3}],
+        data = {'data': [
+                    {
+                        't': '2015-01-01T00:00:00',
+                        'data': {1: 1},
+                    },
+                    {
+                        't': '2015-01-02T00:00:00',
+                        'data': {},
+                    },
+                    {
+                        't': '2015-01-03T00:00:00',
+                        'data': {1: 3},
+                    }
+                ],
                 'streams': [{'device': {'key': 'foo'}, 'id': 1}],
                 'next_page': {'next_query': None}}
 
         cursor = StreamResponseCursor(None, data, fetcher)
         stream = cursor.bind_stream(device_key='foo')
         data = [s for s in stream]
-        self.assertEquals(data, [1, 3])
+        self.assertEquals([d.value for d in data], [1, 3])
 
     def test_bind_one_stream_with_multiple_pages(self):
         StreamManager.MAX_PAGES = 2
@@ -369,19 +395,45 @@ class TestProtocolStreamResponseCursor(unittest.TestCase):
                 if self.iters == 1:
                     raise StopIteration
                 else:
-                    data = {'data': [{1: 4}, {1: 5}, {1: 6}],
-                            'streams': [{'device': {'key': 'foo'}, 'id': 1}],
-                            'next_page': {'next_query': None}}
+                    data = {'data': [
+                        {
+                            't': '2015-01-01T00:00:00',
+                            'data': {1: 4},
+                        },
+                        {
+                            't': '2015-01-02T00:00:00',
+                            'data': {1: 5},
+                        },
+                        {
+                            't': '2015-01-03T00:00:00',
+                            'data': {1: 6},
+                        }
+                    ],
+                    'streams': [{'device': {'key': 'foo'}, 'id': 1}],
+                    'next_page': {'next_query': None}}
                     self.iters += 1
                     return data
 
-        data = {'data': [{1: 1}, {1: 2}, {1: 3}],
+        data = {'data': [
+                    {
+                        't': '2015-01-01T00:00:00',
+                        'data': {1: 1},
+                    },
+                    {
+                        't': '2015-01-02T00:00:00',
+                        'data': {1: 2},
+                    },
+                    {
+                        't': '2015-01-03T00:00:00',
+                        'data': {1: 3},
+                    }
+                ],
                 'streams': [{'device': {'key': 'foo'}, 'id': 1}],
                 'next_page': {'next_query': None}}
 
         cursor = StreamResponseCursor(None, data, Fetcher())
         stream = cursor.bind_stream(device_key='foo')
-        data = [s for s in stream]
+        data = [s.value for s in stream]
         self.assertEquals(data, [1, 2, 3, 4, 5, 6])
 
     def test_bind_multiple_streams_with_single_page(self):
@@ -390,9 +442,20 @@ class TestProtocolStreamResponseCursor(unittest.TestCase):
         def fetcher(cursor):
             raise StopIteration
 
-        data = {'data': [{1: 1, 2: 1},
-                         {1: 2, 2: 2},
-                         {1: 3, 2: 3}],
+        data = {'data': [
+                    {
+                        't': '2015-01-01T00:00:00',
+                        'data': {1: 1, 2: 1},
+                    },
+                    {
+                        't': '2015-01-02T00:00:00',
+                        'data': {1: 2, 2: 2},
+                    },
+                    {
+                        't': '2015-01-03T00:00:00',
+                        'data': {1: 3, 2: 3},
+                    }
+                ],
                 'streams': [
                     {'device': {'key': 'foo'}, 'id': 1},
                     {'device': {'key': 'bar'}, 'id': 2}
@@ -402,8 +465,8 @@ class TestProtocolStreamResponseCursor(unittest.TestCase):
         cursor = StreamResponseCursor(None, data, fetcher)
         stream1 = cursor.bind_stream(device_key='foo')
         stream2 = cursor.bind_stream(device_key='bar')
-        data1 = [s for s in stream1]
-        data2 = [s for s in stream2]
+        data1 = [s.value for s in stream1]
+        data2 = [s.value for s in stream2]
         self.assertEquals(data1, [1, 2, 3])
         self.assertEquals(data2, [1, 2, 3])
 
@@ -418,20 +481,42 @@ class TestProtocolStreamResponseCursor(unittest.TestCase):
                 if self.iters == 1:
                     raise StopIteration
                 else:
-                    data = {'data': [{1: 4, 2: 4},
-                                     {1: 5},
-                                     {1: 6, 2: 6}],
-                            'streams': [
-                                {'device': {'key': 'foo'}, 'id': 1},
-                                {'device': {'key': 'bar'}, 'id': 2}
+                    data = {'data': [
+                            {
+                                't': '2015-01-01T00:00:00',
+                                'data': {1: 4, 2: 4},
+                            },
+                            {
+                                't': '2015-01-02T00:00:00',
+                                'data': {1: 5},
+                            },
+                            {
+                                't': '2015-01-03T00:00:00',
+                                'data': {1: 6, 2: 6},
+                            }
                             ],
-                            'next_page': {'next_query': None}}
+                        'streams': [
+                            {'device': {'key': 'foo'}, 'id': 1},
+                            {'device': {'key': 'bar'}, 'id': 2}
+                        ],
+                        'next_page': {'next_query': None}}
                     self.iters += 1
                     return data
 
-        data = {'data': [{1: 1, 2: 1},
-                         {1: 2, 2: 2},
-                         {1: 3, 2: 3}],
+        data = {'data': [
+                    {
+                        't': '2015-01-01T00:00:00',
+                        'data': {1: 1, 2: 1},
+                    },
+                    {
+                        't': '2015-01-02T00:00:00',
+                        'data': {1: 2, 2: 2},
+                    },
+                    {
+                        't': '2015-01-03T00:00:00',
+                        'data': {1: 3, 2: 3},
+                    }
+                ],
                 'streams': [
                     {'device': {'key': 'foo'}, 'id': 1},
                     {'device': {'key': 'bar'}, 'id': 2}
@@ -441,8 +526,8 @@ class TestProtocolStreamResponseCursor(unittest.TestCase):
         cursor = StreamResponseCursor(None, data, Fetcher())
         stream1 = cursor.bind_stream(device_key='foo')
         stream2 = cursor.bind_stream(device_key='bar')
-        data1 = [s for s in stream1]
-        data2 = [s for s in stream2]
+        data1 = [s.value for s in stream1]
+        data2 = [s.value for s in stream2]
         self.assertEquals(data1, [1, 2, 3, 4, 5, 6])
         self.assertEquals(data2, [1, 2, 3, 4, 6])
 
@@ -457,20 +542,42 @@ class TestProtocolStreamResponseCursor(unittest.TestCase):
                 if self.iters >= 2:
                     raise StopIteration
                 else:
-                    data = {'data': [{1: 1, 2: 4},
-                                     {1: 2},
-                                     {1: 3, 2: 6}],
-                            'streams': [
-                                {'device': {'key': 'foo'}, 'id': 1},
-                                {'device': {'key': 'bar'}, 'id': 2}
+                    data = {'data': [
+                            {
+                                't': '2015-01-01T00:00:00',
+                                'data': {1: 1, 2: 4},
+                            },
+                            {
+                                't': '2015-01-02T00:00:00',
+                                'data': {1: 2},
+                            },
+                            {
+                                't': '2015-01-03T00:00:00',
+                                'data': {1: 3, 2: 6},
+                            }
                             ],
-                            'next_page': {'next_query': None}}
+                        'streams': [
+                            {'device': {'key': 'foo'}, 'id': 1},
+                            {'device': {'key': 'bar'}, 'id': 2}
+                        ],
+                        'next_page': {'next_query': None}}
                     self.iters += 1
                     return data
 
-        data = {'data': [{1: 1, 2: 4},
-                         {1: 2},
-                         {1: 3, 2: 6}],
+        data = {'data': [
+                    {
+                        't': '2015-01-01T00:00:00',
+                        'data': {1: 1, 2: 1},
+                    },
+                    {
+                        't': '2015-01-02T00:00:00',
+                        'data': {1: 2, 2: 2},
+                    },
+                    {
+                        't': '2015-01-03T00:00:00',
+                        'data': {1: 3, 2: 3},
+                    }
+                ],
                 'streams': [
                     {'device': {'key': 'foo'}, 'id': 1},
                     {'device': {'key': 'bar'}, 'id': 2}
@@ -484,10 +591,10 @@ class TestProtocolStreamResponseCursor(unittest.TestCase):
         iters = 0
         while iters < 6:
             iterator = iter(stream1)
-            data1.append(iterator.next())
+            data1.append(iterator.next().value)
             iters += 1
         self.assertEquals(cursor.manager.pages[0].data, None)
-        data2 = [s for s in stream2]
+        data2 = [s.value for s in stream2]
         self.assertEquals(data1, [1, 2, 3, 1, 2, 3])
         self.assertEquals(data2, [4, 6, 4, 6])
 
@@ -502,30 +609,51 @@ class TestProtocolStreamResponseCursor(unittest.TestCase):
                 if self.iters == 1:
                     raise StopIteration
                 else:
-                    data = {'data': [{1: 4, 2: 4},
-                                     {1: 5},
-                                     {1: 6, 2: 6}],
-                            'streams': [
-                                {'device': {'key': 'foo'}, 'id': 1},
-                                {'device': {'key': 'bar'}, 'id': 2}
+                    data = {'data': [
+                            {
+                                't': '2015-01-01T00:00:00',
+                                'data': {1: 4, 2: 4},
+                            },
+                            {
+                                't': '2015-01-02T00:00:00',
+                                'data': {1: 5},
+                            },
+                            {
+                                't': '2015-01-03T00:00:00',
+                                'data': {1: 6, 2: 6},
+                            }
                             ],
-                            'next_page': {'next_query': None}}
+                        'streams': [
+                            {'device': {'key': 'foo'}, 'id': 1},
+                            {'device': {'key': 'bar'}, 'id': 2}
+                        ],
+                        'next_page': {'next_query': None}}
                     self.iters += 1
                     return data
 
-        data = {'data': [{1: 1, 2: 1},
-                         {1: 2, 2: 2},
-                         {1: 3, 2: 3}],
+        data = {'data': [
+                    {
+                        't': '2015-01-01T00:00:00',
+                        'data': {1: 1, 2: 1},
+                    },
+                    {
+                        't': '2015-01-02T00:00:00',
+                        'data': {1: 2, 2: 2},
+                    },
+                    {
+                        't': '2015-01-03T00:00:00',
+                        'data': {1: 3, 2: 3},
+                    }
+                ],
                 'streams': [
                     {'device': {'key': 'foo'}, 'id': 1},
                     {'device': {'key': 'bar'}, 'id': 2}
                 ],
                 'next_page': {'next_query': None}}
-
         cursor = StreamResponseCursor(None, data, Fetcher())
         streams = cursor.streams
         stream_data = []
         for stream in streams:
-            stream_data.append([s for s in stream])
+            stream_data.append([s.value for s in stream])
         self.assertEquals(stream_data[0], [1, 2, 3, 4, 5, 6])
         self.assertEquals(stream_data[1], [1, 2, 3, 4, 6])

--- a/tests/test_protocol_cursor.py
+++ b/tests/test_protocol_cursor.py
@@ -490,3 +490,42 @@ class TestProtocolStreamResponseCursor(unittest.TestCase):
         data2 = [s for s in stream2]
         self.assertEquals(data1, [1, 2, 3, 1, 2, 3])
         self.assertEquals(data2, [4, 6, 4, 6])
+
+    def test_two_dimensional_iteration(self):
+        StreamManager.MAX_PAGES = 2
+
+        class Fetcher(object):
+            def __init__(self):
+                self.iters = 0
+
+            def __call__(self, cursor):
+                if self.iters == 1:
+                    raise StopIteration
+                else:
+                    data = {'data': [{1: 4, 2: 4},
+                                     {1: 5},
+                                     {1: 6, 2: 6}],
+                            'streams': [
+                                {'device': {'key': 'foo'}, 'id': 1},
+                                {'device': {'key': 'bar'}, 'id': 2}
+                            ],
+                            'next_page': {'next_query': None}}
+                    self.iters += 1
+                    return data
+
+        data = {'data': [{1: 1, 2: 1},
+                         {1: 2, 2: 2},
+                         {1: 3, 2: 3}],
+                'streams': [
+                    {'device': {'key': 'foo'}, 'id': 1},
+                    {'device': {'key': 'bar'}, 'id': 2}
+                ],
+                'next_page': {'next_query': None}}
+
+        cursor = StreamResponseCursor(None, data, Fetcher())
+        streams = cursor.streams
+        stream_data = []
+        for stream in streams:
+            stream_data.append([s for s in stream])
+        self.assertEquals(stream_data[0], [1, 2, 3, 4, 5, 6])
+        self.assertEquals(stream_data[1], [1, 2, 3, 4, 6])

--- a/tests/test_protocol_cursor.py
+++ b/tests/test_protocol_cursor.py
@@ -1,6 +1,7 @@
 import mock
 import unittest
 from tempoiq.protocol.cursor import DataPointsCursor, DeviceCursor
+from tempoiq.protocol.cursor import StreamResponseCursor, Page, StreamManager
 
 
 class DummyType(object):
@@ -129,3 +130,318 @@ class TestProtocolCursor(unittest.TestCase):
         self.assertEquals(results[0].key, 'device1')
         self.assertEquals(results[1].key, 'device2')
         self.assertEquals(results[1].sensors[0].key, 'sensor1')
+
+
+class TestProtocolPage(unittest.TestCase):
+    def test_page_is_active(self):
+        page = Page(None, None)
+        self.assertFalse(page.is_active())
+        page.data = 1
+        self.assertTrue(page.is_active())
+
+    def test_garbage_collect_and_reconstruct(self):
+        dummy_cursor = Dummy()
+
+        def dummy_fetcher(cursor):
+            return {'data': 42}
+
+        dummy_cursor.fetcher = dummy_fetcher
+        page = Page(1, None)
+        page.garbage_collect()
+        self.assertEquals(page.data, None)
+        page.reconstruct(dummy_cursor)
+        self.assertEquals(page.data, 42)
+
+
+class TestProtocolStreamManager(unittest.TestCase):
+    def test_initial_state(self):
+        cursor = Dummy()
+        data = {'data': [1, 2, 3], 'next_page': {'next_query': None}}
+        ds = StreamManager(cursor, data, 3)
+        self.assertEquals(ds.active_pages, 1)
+        self.assertEquals(ds.page_size, 3)
+        self.assertEquals(ds.pages[0].data, [1, 2, 3])
+
+    def test_garbage_collection_with_nothing_to_collect_idempotent(self):
+        StreamManager.MAX_PAGES = 2
+        cursor = Dummy()
+        data = {'data': [1, 2, 3], 'next_page': {'next_query': None}}
+        ds = StreamManager(cursor, data, 3)
+        page2 = Page([4, 5, 6], None)
+        ds.active_pages += 1
+        ds.pages[1] = page2
+        ds.active_pointers['key1'].add(0)
+        ds._garbage_collect()
+        self.assertEquals(ds.pages[0].data, [1, 2, 3])
+        self.assertEquals(ds.pages[1].data, [4, 5, 6])
+
+    def test_garbage_collection_with_one_page(self):
+        StreamManager.MAX_PAGES = 1
+        cursor = Dummy()
+        data = {'data': [1, 2, 3], 'next_page': {'next_query': None}}
+        ds = StreamManager(cursor, data, 3)
+        page2 = Page([4, 5, 6], None)
+        ds.active_pages += 1
+        ds.pages[1] = page2
+        ds.active_pointers[0].add('key1')
+        ds._garbage_collect()
+        self.assertEquals(ds.pages[0].data, [1, 2, 3])
+        self.assertEquals(ds.pages[1].data, None)
+
+    def test_garbage_collection_collects_first_available(self):
+        StreamManager.MAX_PAGES = 1
+        cursor = Dummy()
+        data = {'data': [1, 2, 3], 'next_page': {'next_query': None}}
+        ds = StreamManager(cursor, data, 3)
+        page2 = Page([4, 5, 6], None)
+        ds.active_pages += 1
+        ds.pages[1] = page2
+        ds.active_pointers[1].add('key1')
+        ds._garbage_collect()
+        self.assertEquals(ds.pages[0].data, None)
+        self.assertEquals(ds.pages[1].data, [4, 5, 6])
+
+    def test_garbage_collection_doesnt_loop_infinitely(self):
+        StreamManager.MAX_PAGES = 1
+        cursor = Dummy()
+        data = {'data': [1, 2, 3], 'next_page': {'next_query': None}}
+        ds = StreamManager(cursor, data, 3)
+        page2 = Page([4, 5, 6], None)
+        ds.active_pages += 1
+        ds.pages[1] = page2
+        ds.active_pointers[0].add('key1')
+        ds.active_pointers[1].add('key2')
+        ds._garbage_collect()
+        self.assertEquals(ds.pages[0].data, [1, 2, 3])
+        self.assertEquals(ds.pages[1].data, [4, 5, 6])
+
+    def test_data_fetches_by_stream_are_independent(self):
+        StreamManager.MAX_PAGES = 1
+        cursor = Dummy()
+        data = {'data': [1, 2, 3], 'next_page': {'next_query': None}}
+        ds = StreamManager(cursor, data, 3)
+        page2 = Page([4, 5, 6], None)
+        ds.active_pages += 1
+        ds.pages[1] = page2
+        receiver1 = Dummy()
+        receiver2 = Dummy()
+        receiver1.key = 'key1'
+        receiver2.key = 'key2'
+        data1 = ds.next(receiver1)
+        ds.next(receiver2)
+        self.assertEquals(ds.active_pointers[0], set(['key1', 'key2']))
+        ds.next(receiver2)
+        ds.next(receiver2)
+        data2 = ds.next(receiver2)
+        self.assertEquals(ds.pages[0].data, [1, 2, 3])
+        self.assertEquals(ds.pages[1].data, [4, 5, 6])
+        self.assertEquals(data1, 1)
+        self.assertEquals(data2, 4)
+        self.assertEquals(ds.active_pointers[0], set(['key1']))
+        self.assertEquals(ds.active_pointers[1], set(['key2']))
+
+    def test_new_page_fetch_over_limit_forces_a_gc(self):
+        StreamManager.MAX_PAGES = 1
+        cursor = Dummy()
+
+        def _fetch_next():
+            return {'data': [4, 5, 6]}, None
+
+        cursor._fetch_next = _fetch_next
+        data = {'data': [1, 2, 3], 'next_page': {'next_query': None}}
+        ds = StreamManager(cursor, data, 3)
+
+        receiver1 = Dummy()
+        receiver1.key = 'key1'
+        ds.next(receiver1)
+        self.assertEquals(ds.active_pointers[0], set(['key1']))
+        ds.next(receiver1)
+        ds.next(receiver1)
+        data = ds.next(receiver1)
+        self.assertEquals(ds.active_pointers[1], set(['key1']))
+        self.assertEquals(ds.pages[0].data, None)
+        self.assertEquals(ds.pages[1].data, [4, 5, 6])
+        self.assertEquals(data, 4)
+
+    def test_new_page_fetch_over_limit_forces_a_gc_2(self):
+        StreamManager.MAX_PAGES = 2
+        cursor = Dummy()
+
+        def _fetch_next():
+            return {'data': [4, 5, 6]}, None
+
+        cursor._fetch_next = _fetch_next
+        data = {'data': [1, 2, 3], 'next_page': {'next_query': None}}
+        ds = StreamManager(cursor, data, 3)
+
+        receiver1 = Dummy()
+        receiver2 = Dummy()
+        receiver1.key = 'key1'
+        receiver2.key = 'key2'
+        ds.next(receiver2)
+        iters = 0
+        while iters < 8:
+            ds.next(receiver1)
+            iters += 1
+        data = ds.next(receiver1)
+        self.assertEquals(ds.active_pointers[0], set(['key2']))
+        self.assertEquals(ds.active_pointers[1], set([]))
+        self.assertEquals(ds.active_pointers[2], set(['key1']))
+        self.assertEquals(ds.pages[0].data, [1, 2, 3])
+        self.assertEquals(ds.pages[1].data, None)
+        self.assertEquals(ds.pages[2].data, [4, 5, 6])
+        self.assertEquals(data, 6)
+
+    def test_reconstruction_of_old_page(self):
+        StreamManager.MAX_PAGES = 2
+        cursor = Dummy()
+
+        def _fetch_next():
+            return {'data': [4, 5, 6]}, None
+
+        def fetcher(cursor):
+            return {'data': [7, 8, 9]}
+
+        cursor._fetch_next = _fetch_next
+        cursor.fetcher = fetcher
+        data = {'data': [1, 2, 3], 'next_page': {'next_query': None}}
+        ds = StreamManager(cursor, data, 3)
+
+        receiver1 = Dummy()
+        receiver2 = Dummy()
+        receiver1.key = 'key1'
+        receiver2.key = 'key2'
+        iters = 0
+        while iters < 8:
+            ds.next(receiver1)
+            iters += 1
+        data1 = ds.next(receiver1)
+        data2 = ds.next(receiver2)
+        self.assertEquals(ds.active_pointers[0], set(['key2']))
+        self.assertEquals(ds.active_pointers[1], set([]))
+        self.assertEquals(ds.active_pointers[2], set(['key1']))
+        self.assertEquals(ds.pages[0].data, [7, 8, 9])
+        self.assertEquals(ds.pages[1].data, [4, 5, 6])
+        self.assertEquals(ds.pages[2].data, [4, 5, 6])
+        self.assertEquals(data1, 6)
+        self.assertEquals(data2, 7)
+
+
+class TestProtocolStreamResponseCursor(unittest.TestCase):
+    def test_bind_one_stream_with_single_page(self):
+        StreamManager.MAX_PAGES = 2
+
+        def fetcher(cursor):
+            raise StopIteration
+
+        data = {'data': [{1: 1}, {1: 2}, {1: 3}],
+                'streams': [{'device': {'key': 'foo'}, 'id': 1}],
+                'next_page': {'next_query': None}}
+
+        cursor = StreamResponseCursor(None, data, fetcher)
+        stream = cursor.bind_stream(device_key='foo')
+        data = [s for s in stream]
+        self.assertEquals(data, [1, 2, 3])
+
+    def test_bind_one_stream_with_missing_data(self):
+        StreamManager.MAX_PAGES = 2
+
+        def fetcher(cursor):
+            raise StopIteration
+
+        data = {'data': [{1: 1}, {2: 2}, {1: 3}],
+                'streams': [{'device': {'key': 'foo'}, 'id': 1}],
+                'next_page': {'next_query': None}}
+
+        cursor = StreamResponseCursor(None, data, fetcher)
+        stream = cursor.bind_stream(device_key='foo')
+        data = [s for s in stream]
+        self.assertEquals(data, [1, 3])
+
+    def test_bind_one_stream_with_multiple_pages(self):
+        StreamManager.MAX_PAGES = 2
+
+        class Fetcher(object):
+            def __init__(self):
+                self.iters = 0
+
+            def __call__(self, cursor):
+                if self.iters == 1:
+                    raise StopIteration
+                else:
+                    data = {'data': [{1: 4}, {1: 5}, {1: 6}],
+                            'streams': [{'device': {'key': 'foo'}, 'id': 1}],
+                            'next_page': {'next_query': None}}
+                    self.iters += 1
+                    return data
+
+        data = {'data': [{1: 1}, {1: 2}, {1: 3}],
+                'streams': [{'device': {'key': 'foo'}, 'id': 1}],
+                'next_page': {'next_query': None}}
+
+        cursor = StreamResponseCursor(None, data, Fetcher())
+        stream = cursor.bind_stream(device_key='foo')
+        data = [s for s in stream]
+        self.assertEquals(data, [1, 2, 3, 4, 5, 6])
+
+    def test_bind_multiple_streams_with_single_page(self):
+        StreamManager.MAX_PAGES = 2
+
+        def fetcher(cursor):
+            raise StopIteration
+
+        data = {'data': [{1: 1, 2: 1},
+                         {1: 2, 2: 2},
+                         {1: 3, 2: 3}],
+                'streams': [
+                    {'device': {'key': 'foo'}, 'id': 1},
+                    {'device': {'key': 'bar'}, 'id': 2}
+                ],
+                'next_page': {'next_query': None}}
+
+        cursor = StreamResponseCursor(None, data, fetcher)
+        stream1 = cursor.bind_stream(device_key='foo')
+        stream2 = cursor.bind_stream(device_key='bar')
+        data1 = [s for s in stream1]
+        data2 = [s for s in stream2]
+        self.assertEquals(data1, [1, 2, 3])
+        self.assertEquals(data2, [1, 2, 3])
+
+    def test_bind_multiple_streams_with_multiple_pages(self):
+        StreamManager.MAX_PAGES = 2
+
+        class Fetcher(object):
+            def __init__(self):
+                self.iters = 0
+
+            def __call__(self, cursor):
+                if self.iters == 1:
+                    raise StopIteration
+                else:
+                    data = {'data': [{1: 4, 2: 4},
+                                     {1: 5},
+                                     {1: 6, 2: 6}],
+                            'streams': [
+                                {'device': {'key': 'foo'}, 'id': 1},
+                                {'device': {'key': 'bar'}, 'id': 2}
+                            ],
+                            'next_page': {'next_query': None}}
+                    self.iters += 1
+                    return data
+
+        data = {'data': [{1: 1, 2: 1},
+                         {1: 2, 2: 2},
+                         {1: 3, 2: 3}],
+                'streams': [
+                    {'device': {'key': 'foo'}, 'id': 1},
+                    {'device': {'key': 'bar'}, 'id': 2}
+                ],
+                'next_page': {'next_query': None}}
+
+        cursor = StreamResponseCursor(None, data, Fetcher())
+        stream1 = cursor.bind_stream(device_key='foo')
+        stream2 = cursor.bind_stream(device_key='bar')
+        data1 = [s for s in stream1]
+        data2 = [s for s in stream2]
+        self.assertEquals(data1, [1, 2, 3, 4, 5, 6])
+        self.assertEquals(data2, [1, 2, 3, 4, 6])

--- a/tests/test_protocol_row.py
+++ b/tests/test_protocol_row.py
@@ -2,6 +2,7 @@ import unittest
 import pytz
 import datetime
 from tempoiq.protocol.row import Row, SelectionEvaluator, StreamInfo
+from tempoiq.protocol.row import PointStream
 from tempoiq.protocol.row import NoResultError, TooManyResultsError
 from tempoiq.protocol.query.selection import Selection, or_, and_
 from tempoiq.protocol.device import Device
@@ -92,6 +93,8 @@ class TestRow(unittest.TestCase):
         ]
         self.assertEquals(values, expected)
 
+
+class TestSelectionEvaluator(unittest.TestCase):
     def test_selection_evaluator_with_device_key_selector(self):
         headers = [
             {'device': {'key': 'foo', 'name': 'bar',
@@ -348,6 +351,7 @@ class TestRow(unittest.TestCase):
         self.assertEquals(len(results), 1)
         self.assertEquals(results[0]['id'], 0)
 
+class TestStreamInfo(unittest.TestCase):
     def test_stream_info_get_one_returns_one(self):
         headers = [
             {'device': {'key': 'foo', 'name': 'bar',
@@ -401,3 +405,29 @@ class TestRow(unittest.TestCase):
         streams = StreamInfo(headers)
         with self.assertRaises(TooManyResultsError):
             streams.get_one(sensor_name='bar')
+
+
+class TestPointStream(unittest.TestCase):
+    def test_get_device(self):
+        info = {'device': {'key': 'foo', 'name': 'bar',
+                           'attributes': {'baz': 'boz', 'foo': 'bar'}},
+                'sensor': {'key': 'foo', 'name': 'bar',
+                           'attributes': {'baz': 'boz'}},
+                'id': 0}
+        stream = PointStream(info, None)
+        self.assertEquals(stream.device.key, 'foo')
+        self.assertEquals(stream.device.name, 'bar')
+        self.assertEquals(stream.device.attributes,
+                          {'baz': 'boz', 'foo': 'bar'})
+
+    def test_get_sensor(self):
+        info = {'device': {'key': 'foo', 'name': 'bar',
+                           'attributes': {'baz': 'boz', 'foo': 'bar'}},
+                'sensor': {'key': 'foo', 'name': 'bar',
+                           'attributes': {'baz': 'boz'}},
+                'id': 0}
+        stream = PointStream(info, None)
+        self.assertEquals(stream.sensor.key, 'foo')
+        self.assertEquals(stream.sensor.name, 'bar')
+        self.assertEquals(stream.sensor.attributes,
+                          {'baz': 'boz'})

--- a/tests/test_protocol_row.py
+++ b/tests/test_protocol_row.py
@@ -6,6 +6,7 @@ from tempoiq.protocol.row import NoResultError, TooManyResultsError
 from tempoiq.protocol.query.selection import Selection, or_, and_
 from tempoiq.protocol.device import Device
 from tempoiq.protocol.sensor import Sensor
+from tempoiq.protocol.stream import Stream
 
 
 class TestRow(unittest.TestCase):
@@ -323,6 +324,29 @@ class TestRow(unittest.TestCase):
         self.assertEquals(len(results), 2)
         self.assertEquals(results[0]['id'], 0)
         self.assertEquals(results[1]['id'], 1)
+
+    def test_selection_evaluator_with_function_name_selector(self):
+        headers = [
+            {'device': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'sensor': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'function': 'max',
+             'id': 0},
+            {'device': {'key': 'bar', 'name': 'foo',
+                        'attributes': {'baz': 'boz'}},
+             'sensor': {'key': 'foo', 'name': 'baz',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'id': 1}
+        ]
+
+        selection = Selection()
+        selection.add(Stream.function == 'max')
+
+        evaluator = SelectionEvaluator(selection)
+        results = [r for r in evaluator.filter(headers)]
+        self.assertEquals(len(results), 1)
+        self.assertEquals(results[0]['id'], 0)
 
     def test_stream_info_get_one_returns_one(self):
         headers = [

--- a/tests/test_protocol_row.py
+++ b/tests/test_protocol_row.py
@@ -1,7 +1,10 @@
 import unittest
 import pytz
 import datetime
-from tempoiq.protocol.row import Row
+from tempoiq.protocol.row import Row, SelectionEvaluator
+from tempoiq.protocol.query.selection import Selection, or_, and_
+from tempoiq.protocol.device import Device
+from tempoiq.protocol.sensor import Sensor
 
 
 class TestRow(unittest.TestCase):
@@ -86,3 +89,236 @@ class TestRow(unittest.TestCase):
             (('device-2', 'sensor-2'), 3.0)
         ]
         self.assertEquals(values, expected)
+
+    def test_selection_evaluator_with_device_key_selector(self):
+        headers = [
+            {'device': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'sensor': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'id': 0},
+            {'device': {'key': 'bar', 'name': 'foo',
+                        'attributes': {'baz': 'boz'}},
+             'sensor': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'id': 1}
+        ]
+
+        selection = Selection()
+        selection.add(Device.key == 'foo')
+
+        evaluator = SelectionEvaluator(selection)
+        results = [r for r in evaluator.filter(headers)]
+        self.assertEquals(len(results), 1)
+        self.assertEquals(results[0]['id'], 0)
+
+    def test_selection_evaluator_with_sensor_key_selector(self):
+        headers = [
+            {'device': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'sensor': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'id': 0},
+            {'device': {'key': 'bar', 'name': 'foo',
+                        'attributes': {'baz': 'boz'}},
+             'sensor': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'id': 1}
+        ]
+
+        selection = Selection()
+        selection.add(Sensor.key == 'foo')
+
+        evaluator = SelectionEvaluator(selection)
+        results = [r for r in evaluator.filter(headers)]
+        self.assertEquals(len(results), 2)
+        self.assertEquals(results[0]['id'], 0)
+        self.assertEquals(results[1]['id'], 1)
+
+    def test_selection_evaluator_with_device_name_selector(self):
+        headers = [
+            {'device': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'sensor': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'id': 0},
+            {'device': {'key': 'bar', 'name': 'foo',
+                        'attributes': {'baz': 'boz'}},
+             'sensor': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'id': 1}
+        ]
+
+        selection = Selection()
+        selection.add(Device.name == 'bar')
+
+        evaluator = SelectionEvaluator(selection)
+        results = [r for r in evaluator.filter(headers)]
+        self.assertEquals(len(results), 1)
+        self.assertEquals(results[0]['id'], 0)
+
+    def test_selection_evaluator_with_sensor_name_selector(self):
+        headers = [
+            {'device': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'sensor': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'id': 0},
+            {'device': {'key': 'bar', 'name': 'foo',
+                        'attributes': {'baz': 'boz'}},
+             'sensor': {'key': 'foo', 'name': 'baz',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'id': 1}
+        ]
+
+        selection = Selection()
+        selection.add(Sensor.name == 'baz')
+
+        evaluator = SelectionEvaluator(selection)
+        results = [r for r in evaluator.filter(headers)]
+        self.assertEquals(len(results), 1)
+        self.assertEquals(results[0]['id'], 1)
+
+    def test_selection_evaluator_with_device_attribute_selector(self):
+        headers = [
+            {'device': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'sensor': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'id': 0},
+            {'device': {'key': 'bar', 'name': 'foo',
+                        'attributes': {'baz': 'boz'}},
+             'sensor': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'id': 1}
+        ]
+
+        selection = Selection()
+        selection.add(Device.attributes['foo'] == 'bar')
+
+        evaluator = SelectionEvaluator(selection)
+        results = [r for r in evaluator.filter(headers)]
+        self.assertEquals(len(results), 1)
+        self.assertEquals(results[0]['id'], 0)
+
+    def test_selection_evaluator_with_sensor_attribute_selector(self):
+        headers = [
+            {'device': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'sensor': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'id': 0},
+            {'device': {'key': 'bar', 'name': 'foo',
+                        'attributes': {'baz': 'boz'}},
+             'sensor': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'id': 1}
+        ]
+
+        selection = Selection()
+        selection.add(Sensor.attributes['foo'] == 'bar')
+
+        evaluator = SelectionEvaluator(selection)
+        results = [r for r in evaluator.filter(headers)]
+        self.assertEquals(len(results), 2)
+        self.assertEquals(results[0]['id'], 0)
+        self.assertEquals(results[1]['id'], 1)
+
+    def test_selection_evaluator_with_device_compound_selector(self):
+        headers = [
+            {'device': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'sensor': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'id': 0},
+            {'device': {'key': 'bar', 'name': 'foo',
+                        'attributes': {'baz': 'boz'}},
+             'sensor': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'id': 1}
+        ]
+
+        selection = Selection()
+        selection.add(Device.key == 'foo')
+        selection.add(Device.attributes['foo'] == 'bar')
+
+        evaluator = SelectionEvaluator(selection)
+        results = [r for r in evaluator.filter(headers)]
+        self.assertEquals(len(results), 1)
+        self.assertEquals(results[0]['id'], 0)
+
+    def test_selection_evaluator_with_sensor_compound_selector(self):
+        headers = [
+            {'device': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'sensor': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'id': 0},
+            {'device': {'key': 'bar', 'name': 'foo',
+                        'attributes': {'baz': 'boz'}},
+             'sensor': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'id': 1}
+        ]
+
+        selection = Selection()
+        selection.add(Sensor.key == 'foo')
+        selection.add(Sensor.attributes['foo'] == 'bar')
+
+        evaluator = SelectionEvaluator(selection)
+        results = [r for r in evaluator.filter(headers)]
+        self.assertEquals(len(results), 2)
+        self.assertEquals(results[0]['id'], 0)
+        self.assertEquals(results[1]['id'], 1)
+
+    def test_selection_evaluator_with_hybrid_compound_selector(self):
+        headers = [
+            {'device': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'sensor': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'id': 0},
+            {'device': {'key': 'bar', 'name': 'foo',
+                        'attributes': {'baz': 'boz'}},
+             'sensor': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'id': 1}
+        ]
+
+        selection = Selection()
+        clause = or_([Device.key == 'foo', Sensor.attributes['baz'] == 'boz'])
+        selection.add(clause)
+
+        evaluator = SelectionEvaluator(selection)
+        results = [r for r in evaluator.filter(headers)]
+        self.assertEquals(len(results), 2)
+        self.assertEquals(results[0]['id'], 0)
+        self.assertEquals(results[1]['id'], 1)
+
+    def test_selection_evaluator_with_nested_compound_selector(self):
+        headers = [
+            {'device': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'baz': 'boz', 'foo': 'bar'}},
+             'sensor': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'baz': 'boz'}},
+             'id': 0},
+            {'device': {'key': 'bar', 'name': 'foo',
+                        'attributes': {'baz': 'boz'}},
+             'sensor': {'key': 'foo', 'name': 'bar',
+                        'attributes': {'foo': 'bar'}},
+             'id': 1}
+        ]
+
+        selection = Selection()
+        clause1 = and_([Device.key == 'foo',
+                        Sensor.attributes['baz'] == 'boz'])
+        clause2 = and_([Device.key == 'bar',
+                        Sensor.attributes['foo'] == 'bar'])
+        main_clause = or_([clause1, clause2])
+        selection.add(main_clause)
+
+        evaluator = SelectionEvaluator(selection)
+        results = [r for r in evaluator.filter(headers)]
+        self.assertEquals(len(results), 2)
+        self.assertEquals(results[0]['id'], 0)
+        self.assertEquals(results[1]['id'], 1)

--- a/tests/test_query_selection.py
+++ b/tests/test_query_selection.py
@@ -57,18 +57,10 @@ class TestSelectionObjects(unittest.TestCase):
         selection.add(selector)
         self.assertTrue(isinstance(selection.selection, ScalarSelector))
 
-    def test_and_clause_must_be_of_uniform_type(self):
-        selectors = [Device.key == 'foo', Sensor.key == 'bar']
-        self.assertRaises(TypeError, and_, selectors)
-
     def test_and_clause_sets_correct_selection_type(self):
         selectors = [Device.key == 'foo', Device.key == 'bar']
         clause = and_(selectors)
         self.assertEquals(clause.selection_type, 'devices')
-
-    def test_or_clause_must_be_of_uniform_type(self):
-        selectors = [Device.key == 'foo', Sensor.key == 'bar']
-        self.assertRaises(TypeError, or_, selectors)
 
     def test_or_clause_sets_correct_selection_type(self):
         selectors = [Sensor.key == 'foo', Sensor.key == 'bar']


### PR DESCRIPTION
This adds client support for the new response format implemented server side.  The implementation uses the interface as spec'ed out in earlier conversations, with the property `streams` (for all streams) and the method `bind_stream` on the cursor for getting to the data.  The old "row-based" interface is maintained for backwards compatibility, but the user must configure the client constructor based on which version of the response they want to see.

The implementation also introduces some memory and latency management for dealing with usage patterns this new interface provides.  This makes up the bulk of the code, both library and test.

I'm putting this out there to start the review process but docs and end-to-end testing are still to be done.