### PR TITLE
Client support for custom search ordering

### DIFF
--- a/tempoiq/protocol/encoder.py
+++ b/tempoiq/protocol/encoder.py
@@ -179,6 +179,9 @@ class ReadEncoder(TempoIQEncoder):
             builder.operation.name: builder.operation.args
         }
 
+        if builder.ordering is not None:
+            j['search']['ordering'] = builder.ordering
+
         if not j['search']['filters']['devices']:
             if not j['search']['filters']['sensors']:
                 j['search']['filters']['devices'] = 'all'

--- a/tempoiq/protocol/query/builder.py
+++ b/tempoiq/protocol/query/builder.py
@@ -39,6 +39,7 @@ class QueryBuilder(object):
             'sensors': Selection(),
             'rules': Selection()
         }
+        self.ordering = None
         self.pipeline = []
         self.operation = None
 
@@ -175,6 +176,12 @@ class QueryBuilder(object):
         """
         self.pipeline.append(MultiRollup(functions, period, start))
         return self
+
+    def order_by(self, attr, direction):
+        self.ordering = {
+            'attribute': attr,
+            'direction': direction
+        }
 
     def rollup(self, function, period, start=None):
         """Apply a rollup function to the query.

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -285,6 +285,34 @@ class TestReadEncoder(unittest.TestCase):
         }
         self.assertEquals(json.loads(j), expected)
 
+    def test_query_builder_with_ordering(self):
+        qb = QueryBuilder(self.client, Sensor)
+        start = datetime.datetime(2014, 1, 1, 12, 0)
+        end = datetime.datetime(2014, 1, 3, 12, 0)
+        rollup_start = datetime.datetime(2014, 1, 1, 0, 0)
+        qb.filter(Device.key == 'foo')
+        qb.order_by('date_created', 'asc')
+        qb.read(start=start, end=end)
+        j = json.dumps(qb, default=self.read_encoder.default)
+        expected = {
+            'search': {
+                'select': 'sensors',
+                'filters': {
+                    'devices': {'key': 'foo'},
+                    'sensors': 'all'
+                },
+                'ordering': {
+                    'attribute': 'date_created',
+                    'direction': 'asc'
+                }
+            },
+            'read': {
+                'start': '2014-01-01T12:00:00',
+                'stop': '2014-01-03T12:00:00'
+            }
+        }
+        self.assertEquals(json.loads(j), expected)
+
     def test_query_builder_sensor_only_search(self):
         qb = QueryBuilder(self.client, Device)
         qb.filter(Sensor.key == 'foo')


### PR DESCRIPTION
Supports the pending server side feature to allow ordering of a search by device key, created time, or last modified time, both ascending and descending.