### PR TITLE
Don't require specifying http:// when constructing a client

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014 TempoDB Inc.
+Copyright (c) 2015 TempoIQ Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/tempoiq/endpoint.py
+++ b/tempoiq/endpoint.py
@@ -44,6 +44,17 @@ def media_type(media_resource, media_version, suffix='json'):
     return 'application/prs.tempoiq.%s.%s+%s' % (
         media_resource, media_version, suffix)
 
+def construct_url(host, secure, port):
+    if "://" in host:
+        url = host.rstrip('/')
+    else:
+        url = "https://" if secure else "http://"
+        url += host
+
+    if port:
+        url += ":{}".format(port)
+
+    return url
 
 class HTTPEndpoint(object):
     """Represents an HTTP endpoint for accessing a REST API.  Provides
@@ -51,17 +62,17 @@ class HTTPEndpoint(object):
     call the methods on this class, use the :class:`tempoiq.client.Client`
     class instead.
 
-    :param string base_url: the base URL for the endpoint
+    :param string host: the host of the endpoint URL
     :param string key: the API key for the endpoint
-    :param string secret: the API secret for the endpoint"""
+    :param string secret: the API secret for the endpoint
+    :param bool secure: whether to use the HTTPS protocol. Default is True
+    :param int port: the port for connecting to the endpoint. Default is the
+                    standard port for HTTP or HTTPS, depending on whether
+                    secure is True"""
 
-    def __init__(self, base_url, key, secret):
-        if base_url.endswith('/'):
-            self.base_url = base_url + 'v2/'
-        else:
-            #in case people use their own, it really has to end in a
-            #slash so the urljoins will work properly
-            self.base_url = base_url + '/v2/'
+    def __init__(self, host, key, secret, secure=True, port=None):
+        url = construct_url(host, secure, port)
+        self.base_url = url + '/v2/'
 
         self.headers = {
             'User-Agent': 'tempoiq-python/%s' % "1.0.2",

--- a/tempoiq/endpoint.py
+++ b/tempoiq/endpoint.py
@@ -52,7 +52,7 @@ def construct_url(host, secure, port):
         url += host
 
     if port:
-        url += ":{}".format(port)
+        url += ":" + str(port)
 
     return url
 

--- a/tempoiq/session.py
+++ b/tempoiq/session.py
@@ -2,14 +2,16 @@ from client import Client
 from endpoint import HTTPEndpoint
 
 
-def get_session(url, key, secret, read_version='v2'):
+def get_session(host, key, secret, secure=True, port=None, read_version='v2'):
     """Get a :class:`tempoiq.client.Client` instance with the given session
     information.
 
-    :param String url: Backend's base URL, in the form
-                       "https://your-url.backend.tempoiq.com"
+    :param String host: Backend's base URL, in the form
+                       "your-host.backend.tempoiq.com". For legacy reasons,
+                       it is also possible to prepend the URL schema, but this
+                       will be deprecated in the future.
     :param String key: API key
     :param String secret: API secret
     :rtype: :class:`tempoiq.client.Client`"""
-    endpoint = HTTPEndpoint(url, key, secret)
+    endpoint = HTTPEndpoint(host, key, secret, secure, port)
     return Client(endpoint, read_version=read_version)

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -5,7 +5,7 @@ from tempoiq import endpoint as p
 
 class TestEndpoint(unittest.TestCase):
     def setUp(self):
-        self.end = p.HTTPEndpoint('http://www.nothing.com', 'foo', 'bar')
+        self.end = p.HTTPEndpoint('www.nothing.com', 'foo', 'bar')
         monkeypatch_requests(self.end)
 
     def test_make_url_args_list(self):
@@ -53,13 +53,13 @@ class TestEndpoint(unittest.TestCase):
         self.assertEquals(ret, 'foo=2.0')
 
     def test_endpoint_constructor(self):
-        self.assertEquals(self.end.base_url, 'http://www.nothing.com/v2/')
+        self.assertEquals(self.end.base_url, 'https://www.nothing.com/v2/')
         self.assertEquals(self.end.headers['User-Agent'],
                           'tempoiq-python/%s' % '1.0.2')
         self.assertEquals(self.end.headers['Accept-Encoding'], 'gzip')
         self.assertTrue(hasattr(self.end, 'auth'))
 
-    def test_endpoint_constructor_with_slash(self):
+    def test_endpoint_constructor_with_schema(self):
         self.end = p.HTTPEndpoint('http://www.nothing.com', 'foo', 'bar')
         self.assertEquals(self.end.base_url, 'http://www.nothing.com/v2/')
         self.assertEquals(self.end.headers['User-Agent'],
@@ -67,13 +67,21 @@ class TestEndpoint(unittest.TestCase):
         self.assertEquals(self.end.headers['Accept-Encoding'], 'gzip')
         self.assertTrue(hasattr(self.end, 'auth'))
 
+    def test_make_url_with_port(self):
+        ret = p.construct_url('www.example.com', False, 8080)
+        self.assertEquals(ret, 'http://www.example.com:8080')
+
+    def test_make_url_with_trailing_slash(self):
+        ret = p.construct_url('http://www.example.com/', True, None)
+        self.assertEquals(ret, 'http://www.example.com')
+
     def test_endpoint_post(self):
         url = 'series/'
         body = 'foobar'
         self.end.pool.post.return_value = True
         self.end.post(url, body)
         self.end.pool.post.assert_called_once_with(
-            'http://www.nothing.com/v2/series/',
+            'https://www.nothing.com/v2/series/',
             data=body,
             headers=self.end.headers,
             auth=self.end.auth)
@@ -83,7 +91,7 @@ class TestEndpoint(unittest.TestCase):
         self.end.pool.get.return_value = True
         self.end.get(url)
         self.end.pool.get.assert_called_once_with(
-            'http://www.nothing.com/v2/series/',
+            'https://www.nothing.com/v2/series/',
             data='',
             headers=self.end.headers,
             auth=self.end.auth)
@@ -94,7 +102,7 @@ class TestEndpoint(unittest.TestCase):
         self.end.pool.put.return_value = True
         self.end.put(url, body)
         self.end.pool.put.assert_called_once_with(
-            'http://www.nothing.com/v2/series/',
+            'https://www.nothing.com/v2/series/',
             data=body,
             headers=self.end.headers,
             auth=self.end.auth)
@@ -104,7 +112,7 @@ class TestEndpoint(unittest.TestCase):
         self.end.pool.delete.return_value = True
         self.end.delete(url)
         self.end.pool.delete.assert_called_once_with(
-            'http://www.nothing.com/v2/series/',
+            'https://www.nothing.com/v2/series/',
             data='',
             headers=self.end.headers,
             auth=self.end.auth)
@@ -116,7 +124,7 @@ class TestEndpoint(unittest.TestCase):
         self.end.get(url, headers=new_headers)
         merged = p.merge_headers(self.end.headers, new_headers)
         self.end.pool.get.assert_called_once_with(
-            'http://www.nothing.com/v2/series/',
+            'https://www.nothing.com/v2/series/',
             data='',
             headers=merged,
             auth=self.end.auth)


### PR DESCRIPTION
Make the python client consistent with the others, which just use the bare host. 