### PR TITLE
Fixing edge case building urls without domain, with port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ bin/
 include/
 lib/
 docs/build/
+.idea

--- a/tempoiq/endpoint.py
+++ b/tempoiq/endpoint.py
@@ -44,12 +44,11 @@ def media_type(media_resource, media_version, suffix='json'):
     return 'application/prs.tempoiq.%s.%s+%s' % (
         media_resource, media_version, suffix)
 
+
 def construct_url(host, secure, port):
-    if "://" in host:
-        url = host.rstrip('/')
-    else:
-        url = "https://" if secure else "http://"
-        url += host
+    url = host.rstrip('/')
+    if "://" not in host:
+        url = "".join(["https://" if secure else "http://", url])
 
     if port:
         url += ":" + str(port)

--- a/tempoiq/endpoint.py
+++ b/tempoiq/endpoint.py
@@ -46,14 +46,18 @@ def media_type(media_resource, media_version, suffix='json'):
 
 
 def construct_url(host, secure, port):
-    url = host.rstrip('/')
+    url = host
     if "://" not in host:
-        url = "".join(["https://" if secure else "http://", url])
+        domain = "https://" if secure else "http://"
+        url = "".join([domain, url])
 
+    # Strip trailing urls forward slashes for version appending in the endpoint
+    url = url.rstrip('/')
     if port:
         url += ":" + str(port)
 
     return url
+
 
 class HTTPEndpoint(object):
     """Represents an HTTP endpoint for accessing a REST API.  Provides

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -75,6 +75,10 @@ class TestEndpoint(unittest.TestCase):
         ret = p.construct_url('http://www.example.com/', True, None)
         self.assertEquals(ret, 'http://www.example.com')
 
+    def test_make_url_with_trailing_slash_and_port(self):
+        ret = p.construct_url('example.com/', True, 8080)
+        self.assertEquals(ret, 'https://example.com:8080')
+
     def test_endpoint_post(self):
         url = 'series/'
         body = 'foobar'


### PR DESCRIPTION
In this case rstrip wouldn't be called on the host which could end up constructing invalid host url